### PR TITLE
add more attribute method

### DIFF
--- a/go/gosdk/abi.go
+++ b/go/gosdk/abi.go
@@ -394,6 +394,26 @@ func (e envoyFilter) GetSourceAddress() string {
 	return e.getStringAttribute(24) // source.address
 }
 
+func (e envoyFilter) GetRequestMethod() string {
+	return e.getStringAttribute(4) // request.method
+}
+
+func (e envoyFilter) GetRequestHost() string {
+	// return e.getStringAttribute(2) // request.host
+	host, _ := e.GetRequestHeader(":authority")
+	return host
+}
+
+func (e envoyFilter) GetRequestURIPath() string {
+	return e.getStringAttribute(1)
+}
+
+func (e envoyFilter) GetRequestPath() string {
+	// return e.getStringAttribute(0) // request.path
+	host, _ := e.GetRequestHeader(":path")
+	return host
+}
+
 func (e envoyFilter) getStringAttribute(id int) string {
 	var resultBufferPtr *byte
 	var resultBufferLengthPtr int

--- a/go/gosdk/gosdk.go
+++ b/go/gosdk/gosdk.go
@@ -59,6 +59,13 @@ type EnvoyHttpFilter interface {
 	GetSourceAddress() string
 	// GetRequestProtocol gets the request protocol. This corresponds to `request.protocol` attribute https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes.
 	GetRequestProtocol() string
+	// GetRequestMethod gets the request method. This corresponds to `request.method` attribute https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes.
+	GetRequestMethod() string
+	// GetRequestHost gets the request host. This corresponds to `request.host` attribute https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes.
+	GetRequestHost() string
+	// GetRequestPath gets the request path. This corresponds to `request.path` attribute https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes.
+	GetRequestPath() string
+	GetRequestURIPath() string
 }
 
 // HttpFilter is an interface that represents each Http request.

--- a/go/passthrough.go
+++ b/go/passthrough.go
@@ -35,6 +35,12 @@ func (p passthroughFilter) RequestHeaders(e gosdk.EnvoyHttpFilter, endOfStream b
 	}
 	fmt.Printf("gosdk: RequestHeaders, source address: %s\n", e.GetSourceAddress())
 	fmt.Printf("gosdk: RequestHeaders, request protocol: %s\n", e.GetRequestProtocol())
+
+	fmt.Printf("gosdk: RequestHeaders, request method: %s\n", e.GetRequestMethod())
+	fmt.Printf("gosdk: RequestHeaders, request host: %s\n", e.GetRequestHost())
+	fmt.Printf("gosdk: RequestHeaders, request path: %s\n", e.GetRequestPath())
+	fmt.Printf("gosdk: RequestHeaders, request uri path: %s\n", e.GetRequestURIPath())
+
 	return gosdk.RequestHeadersStatusContinue
 }
 


### PR DESCRIPTION

I'm trying to provide usage methods for the commonly used headers, but the ABI told me that this is not supported. Is this the expected design or some kind of error?

```shell
[2025-04-22 10:21:04.355][43][error][dynamic_modules] [source/extensions/filters/http/dynamic_modules/abi_impl.cc:636] Unsupported attribute ID 4 as string
[2025-04-22 10:21:04.355][43][error][dynamic_modules] [source/extensions/filters/http/dynamic_modules/abi_impl.cc:636] Unsupported attribute ID 2 as string
[2025-04-22 10:21:04.355][43][error][dynamic_modules] [source/extensions/filters/http/dynamic_modules/abi_impl.cc:636] Unsupported attribute ID 0 as string
```

I need some guidance, before this, I had no experience in c/ C ++. Please remind me if I missed anything. Thank you!

cc @mathetake