### PR TITLE
Add Docker Compose configuration and quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,28 @@ If you want to explicitly specify the docker image, use `ENVOY_IMAGE` environmen
 ENVOY_IMAGE=foo-bar-image:latest go test . -v -count=1
 ```
 
+## Quick Start with Docker Compose
+
+To quickly start the example, you can use `docker-compose` to set up the environment:
+
+```bash
+docker-compose up -d
+```
+
+This will start the Envoy proxy along with the echo server in the background. Once the setup is complete, you can test the example by running:
+
+```bash
+curl localhost:1062/uuid
+```
+
+This command tests the passthrough and access log filters. If the setup is successful, you should see a response like:
+
+```
+Hello from echo server
+```
+
+You can also explore other endpoints defined in the `envoy.yaml` configuration.
+
 [5b88f941da971de57f29286103c20770811ec67f]: https://github.com/envoyproxy/envoy/tree/5b88f941da971de57f29286103c20770811ec67f
 [Envoy]: https://github.com/envoyproxy/envoy
 [High Level Doc]: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/dynamic_modules

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+services:
+  envoy:
+    image: envoy-with-dynamic-modules:latest
+    container_name: envoy
+    ports:
+      - "1062:1062"
+      - "1063:1063"
+      - "1064:1064"
+    volumes:
+      - ./:/examples
+    working_dir: /examples/integration
+    command: ["envoy", "--config-path", "./envoy.yaml"]
+    networks:
+      - envoy-net
+
+  echo:
+    image: hashicorp/http-echo
+    depends_on:
+      - envoy
+    network_mode: "container:envoy"
+    command:
+      - "-listen=127.0.0.1:1234"
+      - "-text=Hello from echo server"
+
+networks:
+  envoy-net:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./:/examples
     working_dir: /examples/integration
-    command: ["envoy", "--config-path", "./envoy.yaml"]
+    command: ["/bin/sh", "-c", "mkdir -p ./access_logs && envoy --config-path ./envoy.yaml"]
     networks:
       - envoy-net
 


### PR DESCRIPTION
Introduce a Docker Compose setup for the Envoy and echo services, along with a quick start guide in the README to facilitate easy deployment and testing. @mathetake 