### PR TITLE
gosdk: adds scheduler ABI support & example with delay filter

### DIFF
--- a/go/delay.go
+++ b/go/delay.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/envoyproxy/dynamic-modules-examples/go/gosdk"
+)
+
+type (
+	// delayFilterConfig implements [gosdk.HttpFilterConfig].
+	delayFilterConfig struct{}
+	// delayFilter implements [gosdk.HttpFilter].
+	//
+	// This filter demostrates how to use the scheduler to delay the request processing,
+	// and how to use goroutines to perform the asynchronous operations.
+	delayFilter struct {
+		onRequestHeaders time.Time
+		delayLapsed      time.Duration
+	}
+)
+
+// Destroy implements [gosdk.HttpFilterConfig].
+func (p delayFilterConfig) Destroy() {}
+
+// NewFilter implements [gosdk.HttpFilterConfig].
+func (p delayFilterConfig) NewFilter() gosdk.HttpFilter { return &delayFilter{} }
+
+// Destroy implements [gosdk.HttpFilter].
+func (p *delayFilter) Destroy() {}
+
+// RequestHeaders implements [gosdk.HttpFilter].
+func (p *delayFilter) RequestHeaders(e gosdk.EnvoyHttpFilter, endOfStream bool) gosdk.RequestHeadersStatus {
+	// Check if the headers contain the "do-delay" header to trigger the delay.
+	if _, ok := e.GetRequestHeader("do-delay"); !ok {
+		// If the header is not present, continue the request processing.
+		fmt.Println("gosdk: RequestHeaders, do-delay header not found, continuing request processing")
+		return gosdk.RequestHeadersStatusContinue
+	}
+
+	schduler := e.NewScheduler()
+	now := time.Now()
+	p.onRequestHeaders = now
+	go func() {
+		// Simulate some delay.
+		time.Sleep(2 * time.Second)
+		// Commit the event to continue the request processing.
+		schduler.Commit(0)
+	}()
+	fmt.Printf("gosdk: RequestHeaders, delaying request processing for 2 seconds at %s\n", now)
+	return gosdk.RequestHeadersStatusStopIteration
+}
+
+// Sheduled implements gosdk.HttpFilter.
+func (p *delayFilter) Sheduled(e gosdk.EnvoyHttpFilter, eventID uint64) {
+	if eventID != 0 {
+		panic("unexpected eventID in Sheduled: " + strconv.Itoa(int(eventID)))
+	}
+	fmt.Println("gosdk: Sheduled, continuing request processing after delay")
+	p.delayLapsed = time.Since(p.onRequestHeaders)
+	// We can insert some headers at this phase.
+	e.SetRequestHeader("delay-filter-on-scheduled", []byte("yes"))
+	// Then continue the request processing.
+	e.ContinueRequest()
+}
+
+// RequestBody implements [gosdk.HttpFilter].
+func (p *delayFilter) RequestBody(e gosdk.EnvoyHttpFilter, endOfStream bool) gosdk.RequestBodyStatus {
+	return gosdk.RequestBodyStatusContinue
+}
+
+// ResponseHeaders implements [gosdk.HttpFilter].
+func (p *delayFilter) ResponseHeaders(e gosdk.EnvoyHttpFilter, endOfStream bool) gosdk.ResponseHeadersStatus {
+	// Add a response header to indicate the delay.
+	if p.delayLapsed > 0 {
+		e.SetResponseHeader("x-delay-filter-lapsed", []byte(p.delayLapsed.String()))
+	}
+	return gosdk.ResponseHeadersStatusContinue
+}
+
+// ResponseBody implements [gosdk.HttpFilter].
+func (p *delayFilter) ResponseBody(e gosdk.EnvoyHttpFilter, endOfStream bool) gosdk.ResponseBodyStatus {
+	return gosdk.ResponseBodyStatusContinue
+}

--- a/go/header_auth.go
+++ b/go/header_auth.go
@@ -28,6 +28,9 @@ func (p headerAuthFilterConfig) NewFilter() gosdk.HttpFilter {
 	return &headerAuthFilter{authHeaderName: p.authHeaderName}
 }
 
+// Sheduled implements gosdk.HttpFilter.
+func (p headerAuthFilter) Sheduled(gosdk.EnvoyHttpFilter, uint64) {}
+
 // Destroy implements [gosdk.HttpFilter].
 func (p *headerAuthFilter) Destroy() {}
 

--- a/go/main.go
+++ b/go/main.go
@@ -18,6 +18,8 @@ func newHttpFilterConfig(name string, config []byte) gosdk.HttpFilterConfig {
 		return passthroughFilterConfig{}
 	case "header_auth":
 		return headerAuthFilterConfig{authHeaderName: string(config)}
+	case "delay":
+		return delayFilterConfig{}
 	default:
 		panic("unknown filter: " + name)
 	}

--- a/go/passthrough.go
+++ b/go/passthrough.go
@@ -20,6 +20,9 @@ func (p passthroughFilterConfig) Destroy() {}
 // NewFilter implements [gosdk.HttpFilterConfig].
 func (p passthroughFilterConfig) NewFilter() gosdk.HttpFilter { return passthroughFilter{} }
 
+// Sheduled implements gosdk.HttpFilter.
+func (p passthroughFilter) Sheduled(gosdk.EnvoyHttpFilter, uint64) {}
+
 // Destroy implements [gosdk.HttpFilter].
 func (p passthroughFilter) Destroy() {}
 

--- a/integration/envoy.yaml
+++ b/integration/envoy.yaml
@@ -36,6 +36,14 @@ static_resources:
                       dynamic_module_config:
                         name: rust_module
                       filter_name: passthrough
+                  - name: dynamic_modules/conditional_deply
+                    typed_config:
+                      # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/dynamic_modules/v3/dynamic_modules.proto#envoy-v3-api-msg-extensions-dynamic-modules-v3-dynamicmoduleconfig
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_modules.v3.DynamicModuleFilter
+                      dynamic_module_config:
+                        name: go_module
+                        do_not_close: true
+                      filter_name: delay
                   - name: dynamic_modules/access_logger
                     typed_config:
                       # https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/dynamic_modules/v3/dynamic_modules.proto#envoy-v3-api-msg-extensions-dynamic-modules-v3-dynamicmoduleconfig


### PR DESCRIPTION
This implements the scheduler ABI https://github.com/envoyproxy/envoy/pull/39765 in Go SDK and adds an example using it. This allows the module to freely perform the asynchronous operation per request without blocking the entire thread.

Ref #25 