### PR TITLE
fix(build): resolve Linux cp error and add strict existence check for…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,10 @@ build-rust: ## Build the Rust dynamic module.
 	@cd rust && cargo build
 	@$(call print_success,Rust dynamic module built at rust/target/debug/librust_module.so)
 	@$(call print_task,Copying Rust dynamic module for easier use with Envoy)
-	@cp rust/target/debug/librust_module.dylib integration/librust_module.so || true
-	@cp rust/target/debug/librust_module.so integration/librust_module.so || true
+	@test -f rust/target/debug/librust_module.so || test -f rust/target/debug/librust_module.dylib || { echo "ERROR: No dynamic module found in rust/target/debug/"; exit 1; }
+	@cp rust/target/debug/librust_module.so integration/librust_module.so 2>/dev/null || \
+	 cp rust/target/debug/librust_module.dylib integration/librust_module.so 2>/dev/null || \
+	 (echo "ERROR: Module not found"; exit 1)
 
 .PHONY: integration-test
 integration-test: build-go build-rust ## Run the integration tests.


### PR DESCRIPTION
### Scenario 1: The "Happy Path" (Linux)

**Why**: This fix resolves a cp error on Linux environments where the Makefile incorrectly looked for macOS `.dylib` files, and it ensures the build process exits with an error code if no library is produced.

```
:~/CODE/dynamic-modules-examples$ make build-rust                                                                                                       
[TASK] Building Rust dynamic module               
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling cfg-if v1.0.1        
   Compiling libc v0.2.174        
   Compiling glob v0.3.2          
   Compiling prettyplease v0.2.35 
   Compiling memchr v2.7.5        
   Compiling regex-syntax v0.8.5  
   Compiling minimal-lexical v0.2.1
   Compiling bindgen v0.70.1       
   Compiling either v1.15.0        
   Compiling zerocopy v0.8.26      
   Compiling libloading v0.8.8     
   Compiling getrandom v0.3.3      
   Compiling log v0.4.27
   Compiling itertools v0.13.0
   Compiling predicates-core v1.0.9
   Compiling shlex v1.3.0 
   Compiling bitflags v2.9.1
   Compiling rustc-hash v1.1.0
   Compiling mockall_derive v0.13.1
   Compiling serde v1.0.219
   Compiling termtree v0.5.1
   Compiling anstyle v1.0.11
   Compiling fragile v2.0.1
   Compiling clang-sys v1.8.1                                                                                                                                                        
   Compiling predicates-tree v1.0.12
   Compiling nom v7.1.3
   Compiling predicates v3.1.3
   Compiling serde_json v1.0.140
   Compiling downcast v0.11.0
   Compiling itoa v1.0.15
   Compiling ryu v1.0.20
   Compiling quote v1.0.40
   Compiling syn v2.0.104
   Compiling rand_core v0.9.3
   Compiling regex-automata v0.4.9
   Compiling cexpr v0.6.0
   Compiling ppv-lite86 v0.2.21
   Compiling rand_chacha v0.9.0
   Compiling rand v0.9.1
   Compiling regex v1.11.1
   Compiling matchers v0.2.0
   Compiling serde_derive v1.0.219
   Compiling mockall v0.13.1
   Compiling envoy-proxy-dynamic-modules-rust-sdk v0.1.0 (https://github.com/envoyproxy/envoy?rev=6d9bb7d9a85d616b220d1f8fe67b61f82bbdb8d3#6d9bb7d9)
   Compiling envoy-proxy-dynamic-modules-rust-sdk-examples v0.1.0 (/home/<masked>/CODE/dynamic-modules-examples/rust)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.29s
  ✓ Rust dynamic module built at rust/target/debug/librust_module.so
[TASK] Copying Rust dynamic module for easier use with Envoy
:~/CODE/dynamic-modules-examples$ ls
build  CODEOWNERS  Dockerfile  go  integration  librust_module.so  LICENSE  Makefile  README.md  rust

:~/CODE/dynamic-modules-examples$ ll integration/librust_module.so
-rwxr-x--- 1 <masked> <group masked> 34972648 Mar  8 08:19 integration/librust_module.so*
```

### Scenario 2: The "Happy Path" (macOS Simulation)

**macOS Simulation**: I manually created a dummy `.dylib` file with test content `Test 08032026-001` in the build directory to verify that the script correctly identifies and copies the Darwin-specific extension when running on a Mac-like setup.

```
:~/CODE/dynamic-modules-examples$ git diff
diff --git a/Makefile b/Makefile
index 25627cb..858d5a0 100644
--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,13 @@ build-go: ## Build the Go dynamic module.
 .PHONY: build-rust
 build-rust: ## Build the Rust dynamic module.
        @$(call print_task,Building Rust dynamic module)
-       @cd rust && cargo build
+#      @cd rust && cargo build
        @$(call print_success,Rust dynamic module built at rust/target/debug/librust_module.so)
        @$(call print_task,Copying Rust dynamic module for easier use with Envoy)
-       @cp rust/target/debug/librust_module.dylib integration/librust_module.so || true
-       @cp rust/target/debug/librust_module.so integration/librust_module.so || true
+       @test -f rust/target/debug/librust_module.so || test -f rust/target/debug/librust_module.dylib || { echo "ERROR: No dynamic module found in rust/target/debug/"; exit 1; }
+       @cp rust/target/debug/librust_module.so integration/librust_module.so 2>/dev/null || \
+        cp rust/target/debug/librust_module.dylib integration/librust_module.so 2>/dev/null || \
+        (echo "ERROR: Module not found"; exit 1)
 
 .PHONY: integration-test
 integration-test: build-go build-rust ## Run the integration tests.
F:~/CODE/dynamic-modules-examples$ 
:~/CODE/dynamic-modules-examples$ 
:~/CODE/dynamic-modules-examples$ rm -rf rust/target
:~/CODE/dynamic-modules-examples$ mkdir -p rust/target/debug
:~/CODE/dynamic-modules-examples$ echo "Test 08032026-001" > rust/target/debug/librust_module.dylib
:~/CODE/dynamic-modules-examples$ cat rust/target/debug/librust_module.dylib
Test 08032026-001
:~/CODE/dynamic-modules-examples$ make build-rust
[TASK] Building Rust dynamic module
  ✓ Rust dynamic module built at rust/target/debug/librust_module.so
[TASK] Copying Rust dynamic module for easier use with Envoy
:~/CODE/dynamic-modules-examples$ ll integration/librust_module.so
-rwxr-x--- 1 <masked> <group masked> 18 Mar  8 08:20 integration/librust_module.so*
:~/CODE/dynamic-modules-examples$ cat integration/librust_module.so
Test 08032026-001
```

### Scenario 3: The "Fail Gracefully" Path

**Graceful Failure Test**: I cleared all build artifacts and ran the command to confirm that the `test -f` logic correctly triggers a non-zero exit code (`Error 1`) and prints a descriptive error message instead of failing silently.

```
:~/CODE/dynamic-modules-examples$ 
:~/CODE/dynamic-modules-examples$ rm rust/target/debug/librust_module.dylib
:~/CODE/dynamic-modules-examples$ 
:~/CODE/dynamic-modules-examples$ 
:~/CODE/dynamic-modules-examples$ make build-rust
[TASK] Building Rust dynamic module
  ✓ Rust dynamic module built at rust/target/debug/librust_module.so
[TASK] Copying Rust dynamic module for easier use with Envoy
ERROR: No dynamic module found in rust/target/debug/
make: *** [Makefile:100: build-rust] Error 1

```
